### PR TITLE
Fix: missing gravity term in set_trajectory() function

### DIFF
--- a/sciencebirdsagents/Utils/trajectory_planner.py
+++ b/sciencebirdsagents/Utils/trajectory_planner.py
@@ -152,10 +152,13 @@ class SimpleTrajectoryPlanner:
         # find the launch angle
         self._theta = atan2(self._release.Y - self._ref.Y, self._ref.X - self._release.X)
 
+        # gravity
+        g = 0.48 * 9.81 / self.scale_factor
+
         # work out initial velocities and coefficients of the parabola
         self._ux = self._velocity * cos(self._theta)
         self._uy = self._velocity * sin(self._theta)
-        self._a = -0.5 / (self._ux * self._ux)
+        self._a = -0.5 / (self._ux * self._ux) * g
         self._b = self._uy / self._ux
 
         # work out points of the trajectory


### PR DESCRIPTION
# Description

Fixes a bug in SimpleTrajectoryPlanner.set_trajectory() function.
There was a missing term for gravity in the calculation of the y-axis position of the parabolic equation.

Fixes #8

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change